### PR TITLE
Safari workaround

### DIFF
--- a/scroll-to-hash.html
+++ b/scroll-to-hash.html
@@ -1,15 +1,27 @@
 <script>
 // Workaround for Safari not scrolling to URL fragment identifiers
-// on fresh page loads. Waits for Quarto's post-load DOM rendering
-// (sidebar, TOC, MathJax) to complete before scrolling.
+// on fresh page loads. Uses MutationObserver to wait for Quarto's
+// post-load DOM rendering (sidebar, TOC, MathJax) to settle before
+// scrolling. Scrolls as soon as DOM changes stop for 80ms.
 window.addEventListener('load', function () {
-  if (window.location.hash) {
-    setTimeout(function () {
-      var el = document.querySelector(window.location.hash);
-      if (el) {
-        el.scrollIntoView();
-      }
-    }, 400);
-  }
+  if (!window.location.hash) return;
+  var el = document.querySelector(window.location.hash);
+  if (!el) return;
+
+  var timer;
+  var observer = new MutationObserver(function () {
+    clearTimeout(timer);
+    timer = setTimeout(function () {
+      observer.disconnect();
+      el.scrollIntoView();
+    }, 80);
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  timer = setTimeout(function () {
+    observer.disconnect();
+    el.scrollIntoView();
+  }, 80);
 });
 </script>

--- a/scroll-to-hash.html
+++ b/scroll-to-hash.html
@@ -1,0 +1,15 @@
+<script>
+// Workaround for Safari not scrolling to URL fragment identifiers
+// on fresh page loads. Waits for Quarto's post-load DOM rendering
+// (sidebar, TOC, MathJax) to complete before scrolling.
+window.addEventListener('load', function () {
+  if (window.location.hash) {
+    setTimeout(function () {
+      var el = document.querySelector(window.location.hash);
+      if (el) {
+        el.scrollIntoView();
+      }
+    }, 400);
+  }
+});
+</script>


### PR DESCRIPTION
Safari has a long-standing issue where it doesn't reliably scroll to fragment identifiers (#anchor).

The fix is to add javascript in the the form of an html fragment to each rendered page with the following logic:
- after page load, watch for DOM changes to stop (80ms of quiet), then scroll to the URL's #fragment target. 

This way the <script> is  part of the page itself — no external file to resolve, no path issues across subdirectories.